### PR TITLE
外部から正規認証を経ずにAPIを利用できる脆弱性の修正

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -1,0 +1,26 @@
+{
+    "headersPattern": {
+        "external": [
+            {
+                "key": "host",
+                "value": ".+\\.pxrsrc\\.me\\.uk$"
+            },
+            {
+                "key": "x-amzn-trace-id",
+                "value": "^[a-zA-Z]+=[0-9]-[a-f0-9]{8}-[a-f0-9]{24}$"
+            }
+        ],
+        "betweenBlocks": [
+            {
+                "key": "host",
+                "value": "^(root|external|application[0-9]{6}|consumer[0-9]{6}|region[0-9]{6}|trader[0-9]{6})-service$"
+            }
+        ],
+        "withinBlock": [
+            {
+                "key": "host",
+                "value": "^localhost(|:[0-9]{4})$"
+            }
+        ]
+    }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9286,6 +9286,11 @@
         }
       }
     },
+    "request-context": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/request-context/-/request-context-2.0.0.tgz",
+      "integrity": "sha512-DrC/YlstsROzzpF7AUkgMa4I/7f/gV7z7EQZ2FBMmhI2JkyT1kXEPiZkog0tsyYYaRz9LuQpvyyqa/xsHXzexw=="
+    },
     "request-promise-core": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.3.tgz",

--- a/src/tests/Session.ts
+++ b/src/tests/Session.ts
@@ -1,0 +1,43 @@
+/** Copyright 2022 NEC Corporation
+Released under the MIT license.
+https://opensource.org/licenses/mit-license.php
+*/
+/**
+ * セッション情報
+ */
+export namespace Session {
+    /**
+    * 正常(流通制御)
+    */
+    export const PXR_ROOT = JSON.stringify({
+        sessionId: '494a44bb97aa0ef964f6a666b9019b2d20bf05aa811919833f3e0c0ae2b09b38',
+        operatorId: 1,
+        type: 3,
+        loginId: 'test-user',
+        name: 'test-user',
+        mobilePhone: '0311112222',
+        auth: {
+            member: {
+                add: true,
+                update: true,
+                delete: true
+            }
+        },
+        lastLoginAt: '2020-01-01T00:00:00.000+0900',
+        attributes: {},
+        roles: [
+            {
+                _value: 1,
+                _ver: 1
+            }
+        ],
+        block: {
+            _value: 1000110,
+            _ver: 1
+        },
+        actor: {
+            _value: 1000001,
+            _ver: 1
+        }
+    });
+}


### PR DESCRIPTION
## 修正方針
ヘッダーにセッション情報が設定されているとき、ヘッダーを参照し通信経路を判定する処理を追加した。
未ログイン状態で通信するとき通信経路に応じたエラー処理を追加した。

## 修正内容
### 通信経路の判定
リクエストヘッダに対してALB (Application Load Balance)で自動設定されるヘッダ `x-amzn-trace-id` とヘッダ `host` の値をチェックし通信経路の種別の判定を行う。
チェックパターンは `config.json` の `headersPattern` で管理する。

通信経路の種別
- **外部通信** 
- **Block間通信** 
- **Block内通信**

### エラー処理
`外部通信である` かつ (`Block間通信でない` もしくは `Block内通信でない`) のとき未ログインエラーを送出する

## 注意事項
 `config.json` 中 `headersPattern` の `key` と `value` は、環境依存の値を含むため開発環境に応じて変更が必要。
`key: x-amzn-trance-id` : AWSのALBを使用する場合に利用する。他環境の場合は、 `key` と `value` 両方の変更が必要。
`key: host`, `value: ALBドメイン名` : AWSのALBを使用する場合に利用する。他環境の場合は、`value` の変更が必要。

## UT結果
```bash
$ npm run test:unit

> pxr-block-proxy-service@1.0.0 test:unit C:\Users\ito.shotaro\ICF_AutoCapsule_disabled\My_PxR_OSS\pxr-block-proxy-service
> jest --coverage --forceExit --detectOpenHandles --runInBand --config=jest.unit.config.js

 PASS  src/tests/Proxy.spec.ts (23.085 s)
 PASS  src/tests/UsingMultipleApiKeysOnceRequest.spec.ts
 PASS  src/tests/BufferRequest.spec.ts
 PASS  src/tests/UsingMultipleApiKeysOnceRequest.ind.spec.ts
 PASS  src/tests/Proxy.auth.spec.ts
 PASS  src/tests/ReverseProxy.spec.ts
 PASS  src/tests/AbnormalReverseProxy.token.spec.ts
 PASS  src/tests/AbnormalProxy.reverse.spec.ts
 PASS  src/tests/AbnormalProxy.token.spec.ts
 PASS  src/tests/AbnormalProxy.catalog.spec.ts
(node:17452) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 message listeners added to [EventEmitter]. Use emitter.setMaxListeners() to increase limit
 PASS  src/tests/AbnormalProxy.auth.spec.ts
----------------------------|---------|----------|---------|---------|-------------------
File                        | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
----------------------------|---------|----------|---------|---------|-------------------
All files                   |     100 |      100 |     100 |     100 | 
 src                        |     100 |      100 |     100 |     100 | 
  index.ts                  |     100 |      100 |     100 |     100 | 
 src/domains                |     100 |      100 |     100 |     100 | 
  CatalogDomain.ts          |     100 |      100 |     100 |     100 | 
  ProxyRequestDomain.ts     |     100 |      100 |     100 |     100 | 
 src/repositories           |     100 |      100 |     100 |     100 | 
  EntityOperation.ts        |     100 |      100 |     100 |     100 |                   
 src/repositories/postgres  |     100 |      100 |     100 |     100 | 
  ProxyLog.ts               |     100 |      100 |     100 |     100 | 
 src/resources              |     100 |      100 |     100 |     100 | 
  IndProxyController.ts     |     100 |      100 |     100 |     100 | 
  ProxyController.ts        |     100 |      100 |     100 |     100 | 
  ReverseProxyController.ts |     100 |      100 |     100 |     100 | 
 src/resources/dto          |     100 |      100 |     100 |     100 |                   
  ProxyReqDto.ts            |     100 |      100 |     100 |     100 |                   
 src/resources/validator    |     100 |      100 |     100 |     100 | 
  ProxyValidator.ts         |     100 |      100 |     100 |     100 | 
 src/services               |     100 |      100 |     100 |     100 |                   
  AccessControlService.ts   |     100 |      100 |     100 |     100 |                   
  CatalogService.ts         |     100 |      100 |     100 |     100 | 
  ProxyService.ts           |     100 |      100 |     100 |     100 | 
  ReverseProxyService.ts    |     100 |      100 |     100 |     100 | 
 src/services/dto           |     100 |      100 |     100 |     100 | 
  ProxyServiceDTO.ts        |     100 |      100 |     100 |     100 | 
----------------------------|---------|----------|---------|---------|-------------------

Test Suites: 11 passed, 11 total
Tests:       165 passed, 165 total
Snapshots:   0 total
Time:        47.205 s, estimated 62 s
Ran all test suites.
jest-html-reporter >> Report generated (./coverage-unit/report.html)
```