### PR TITLE
commit modified version bugfix/#13

### DIFF
--- a/src/common/DoRequest.ts
+++ b/src/common/DoRequest.ts
@@ -8,6 +8,8 @@ import { systemLogger } from './logging';
 import AppError from './AppError';
 import Config from './Config';
 const Message = Config.ReadConfig('./config/message.json');
+const dns = require('dns');
+dns.setDefaultResultOrder('ipv4first');
 /* eslint-enable */
 
 /**


### PR DESCRIPTION
# pullrequestタイトル
node18からipv6が優先することに伴いlocalhostの通信に失敗する。

# 概要
## 環境（UT実行バージョン）
- postgres: 15.6
```
$ psql --version
psql (PostgreSQL) 15.6
```
- node: v18.16.0
```
$ fnm use 18
Using Node v18.16.0
```

## 対処内容
- nodejsの通信をipv6優先→ipv4優先に修正した。
- src/common/DoRequest.ts内で以下を追記し、ipv4を優先して利用する設定を入れた。
```
const dns = require('dns');
dns.setDefaultResultOrder('ipv4first');
```

# コマンド実行結果
## npm install実行結果
```
$ npm install
npm WARN deprecated @types/moment@2.13.0: This is a stub types definition for Mome
nt (https://github.com/moment/moment). Moment provides its own type definitions, s
o you don't need @types/moment installed!
npm WARN deprecated @types/log4js@2.3.5: This is a stub types definition for log4j
s (https://github.com/nomiddlename/log4js-node). log4js provides its own type defi
nitions, so you don't need @types/log4js installed!
npm WARN deprecated @types/helmet@4.0.0: This is a stub types definition. helmet p
rovides its own type definitions, so you do not need this installed.
npm WARN deprecated @babel/plugin-proposal-export-namespace-from@7.18.9: This prop
osal has been merged to the ECMAScript standard and thus this plugin is no longer
maintained. Please use @babel/plugin-transform-export-namespace-from instead.
npm WARN deprecated har-validator@5.1.5: this library is no longer supported
npm WARN deprecated uuid@3.4.0: Please upgrade  to version 7 or higher.  Older ver
sions may use Math.random() in certain circumstances, which is known to be problem
atic.  See https://v8.dev/blog/math-random for details.
npm WARN deprecated request@2.88.2: request has been deprecated, see https://githu
b.com/request/request/issues/3142

added 996 packages, and audited 997 packages in 2m

158 packages are looking for funding
  run `npm fund` for details

3 moderate severity vulnerabilities

To address issues that do not require attention, run:
  npm audit fix

Some issues need review, and may require choosing
a different dependency.

Run `npm audit` for details.

```

## ビルド実行結果
```
$ npm run build

> pxr-block-proxy-service@1.0.0 build
> npm-run-all -s lint build:ts


> pxr-block-proxy-service@1.0.0 lint
> eslint ./src/index.ts src/**/*.ts


> pxr-block-proxy-service@1.0.0 build:ts
> node ./node_modules/typescript/bin/tsc

```

## UT実行結果
```
$ npm run test:unit

> pxr-block-proxy-service@1.0.0 test:unit
> jest --coverage --forceExit --detectOpenHandles --runInBand --config=jest.unit.c
onfig.js

 PASS  src/tests/Proxy.spec.ts (51.351 s)
 PASS  src/tests/UsingMultipleApiKeysOnceRequest.spec.ts (6.389 s)
 PASS  src/tests/ReverseProxy.spec.ts
 PASS  src/tests/UsingMultipleApiKeysOnceRequest.ind.spec.ts (6.228 s)
 PASS  src/tests/AbnormalProxy.catalog.spec.ts
 PASS  src/tests/AbnormalProxy.token.spec.ts
 PASS  src/tests/AbnormalProxy.auth.spec.ts
 PASS  src/tests/Proxy.auth.spec.ts
 PASS  src/tests/AbnormalProxy.reverse.spec.ts
 PASS  src/tests/AbnormalReverseProxy.token.spec.ts
(node:18568) MaxListenersExceededWarning: Possible EventEmitter memory leak detect
ed. 11 message listeners added to [EventEmitter]. Use emitter.setMaxListeners() to
 increase limit
(Use `node --trace-warnings ...` to show where the warning was created)
 PASS  src/tests/BufferRequest.spec.ts
---------------------|---------|----------|---------|---------|-------------------
File                 | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
---------------------|---------|----------|---------|---------|-------------------
All files            |     100 |      100 |     100 |     100 |
 src                 |     100 |      100 |     100 |     100 |
  index.ts           |     100 |      100 |     100 |     100 |
 src/domains         |     100 |      100 |     100 |     100 |
  CatalogDomain.ts   |     100 |      100 |     100 |     100 |
  ...equestDomain.ts |     100 |      100 |     100 |     100 |
 src/repositories    |     100 |      100 |     100 |     100 |
  EntityOperation.ts |     100 |      100 |     100 |     100 |
 ...itories/postgres |     100 |      100 |     100 |     100 |
  ProxyLog.ts        |     100 |      100 |     100 |     100 |
 src/resources       |     100 |      100 |     100 |     100 |
  ...xyController.ts |     100 |      100 |     100 |     100 |
  ProxyController.ts |     100 |      100 |     100 |     100 |
  ...xyController.ts |     100 |      100 |     100 |     100 |
 src/resources/dto   |     100 |      100 |     100 |     100 |
  ProxyReqDto.ts     |     100 |      100 |     100 |     100 |
 ...ources/validator |     100 |      100 |     100 |     100 |
  ProxyValidator.ts  |     100 |      100 |     100 |     100 |
 src/services        |     100 |      100 |     100 |     100 |
  ...ntrolService.ts |     100 |      100 |     100 |     100 |
  CatalogService.ts  |     100 |      100 |     100 |     100 |
  ProxyService.ts    |     100 |      100 |     100 |     100 |
  ...ProxyService.ts |     100 |      100 |     100 |     100 |
 src/services/dto    |     100 |      100 |     100 |     100 |
  ProxyServiceDTO.ts |     100 |      100 |     100 |     100 |
---------------------|---------|----------|---------|---------|-------------------

Test Suites: 11 passed, 11 total
Tests:       165 passed, 165 total
Snapshots:   0 total
Time:        90.994 s
Ran all test suites.

```