### PR TITLE
共有定義を「同意不要」で定義すると、蓄積イベント通知が送信されない問題の修正 issue/#15

### DIFF
--- a/src/resources/ReverseProxyController.ts
+++ b/src/resources/ReverseProxyController.ts
@@ -77,7 +77,7 @@ export default class ReverseProxyController {
         const operator = await OperatorService.authMe(req);
 
         // APIトークンを認証させる
-        await AccessControlService.certifyToken(
+        const { parameter } = await AccessControlService.certifyToken(
             req.headers.token + '',
             'POST',
             dto.toPath,
@@ -93,6 +93,11 @@ export default class ReverseProxyController {
 
         // データベースへ登録する
         await ReverseProxyService.saveLog(dto, operator, 'POST');
+
+        // toPath が /book-operate/share/search の場合はレスポンスのフィルタ処理を行う
+        if (dto.toPath === '/book-operate/share/search') {
+            result.body = ReverseProxyService.filterShareResponse(result.body, parameter);
+        }
 
         // レスポンスを生成、処理を終了する
         res

--- a/src/services/AccessControlService.ts
+++ b/src/services/AccessControlService.ts
@@ -71,6 +71,9 @@ export default class AccessControlService {
             if (statusCode === 500 || statusCode === 503) {
                 throw new AppError(Message.FAILED_ACCESS_CONTROL_SERVICE, 500);
             }
+            if (statusCode === 401) {
+                throw new AppError(result.body.message, 401);
+            }
             if (statusCode !== 200) {
                 throw new AppError(Message.NOT_PERMISSION_THIS_REQUEST, 401);
             }
@@ -121,6 +124,7 @@ export default class AccessControlService {
                 // エラーオブジェクトを生成し、スローする
                 throw new AppError(Message.FAILED_TO_COLLATE_TOKEN, 400);
             }
+            return result.body;
         } catch (err) {
             if (err.name === AppError.NAME) {
                 throw err;

--- a/src/services/ReverseProxyService.ts
+++ b/src/services/ReverseProxyService.ts
@@ -124,4 +124,76 @@ export default class ReverseProxyService {
         entity.updatedBy = operator.loginId;
         await EntityOperation.saveEntity(entity);
     }
+
+    /**
+     * 共有のレスポンスのフィルタ処理を行う
+     * @param responseBody
+     * @param parameter
+     */
+    static filterShareResponse (responseBody: any, parameter: string) {
+        const body = responseBody;
+        if (parameter) {
+            let filterInfo = null;
+            try {
+                filterInfo = JSON.parse(parameter);
+            } catch (err) {
+                // 無効なパラメータの場合はフィルタ処理を行わない
+                return body;
+            }
+
+            if (body.document && body.document.length > 0) {
+                if (filterInfo && filterInfo.document && filterInfo.document.length > 0) {
+                    const filteredDocument = [];
+                    for (const doc of body.document) {
+                        if (filterInfo.document.some((elem: { _value: number; _ver: number; }) => elem._value === Number(doc.code.value._value) && elem._ver === Number(doc.code.value._ver))) {
+                            filteredDocument.push(doc);
+                        }
+                    }
+                    body.document = filteredDocument;
+                } else {
+                    body.document = [];
+                }
+            }
+
+            if (body.event && body.event.length > 0) {
+                if (filterInfo && filterInfo.event && filterInfo.event.length > 0) {
+                    const filteredEvent = [];
+                    for (const eve of body.event) {
+                        if (filterInfo.event.some((elem: { _value: number; _ver: number; }) => elem._value === Number(eve.code.value._value) && elem._ver === Number(eve.code.value._ver))) {
+                            if (eve.thing && eve.thing.length > 0) {
+                                const filteredEveThing = [];
+                                if (filterInfo && filterInfo.thing && filterInfo.thing.length > 0) {
+                                    for (const thi of eve.thing) {
+                                        if (filterInfo.thing.some((elem: { _value: number; _ver: number; }) => elem._value === Number(thi.code.value._value) && elem._ver === Number(thi.code.value._ver))) {
+                                            filteredEveThing.push(thi);
+                                        }
+                                    }
+                                }
+                                eve.thing = filteredEveThing.length > 0 ? filteredEveThing : null;
+                            }
+                            filteredEvent.push(eve);
+                        }
+                    }
+                    body.event = filteredEvent;
+                } else {
+                    body.event = [];
+                }
+            }
+
+            if (body.thing && body.thing.length > 0) {
+                if (filterInfo && filterInfo.thing && filterInfo.thing.length > 0) {
+                    const filteredThing = [];
+                    for (const thi of body.thing) {
+                        if (filterInfo.thing.some((elem: { _value: number; _ver: number; }) => elem._value === Number(thi.code.value._value) && elem._ver === Number(thi.code.value._ver))) {
+                            filteredThing.push(thi);
+                        }
+                    }
+                    body.thing = filteredThing;
+                } else {
+                    body.thing = [];
+                }
+            }
+        }
+        return body;
+    }
 }

--- a/src/tests/ReverseProxy.spec.ts
+++ b/src/tests/ReverseProxy.spec.ts
@@ -12,7 +12,7 @@ fs.writeFileSync('./config/port.json', changeLines);
 // テスト用モジュールのインポート
 import * as supertest from 'supertest';
 import Application from '../index';
-import { StubService, StubAbnormalService, StubAccessControlService, StubOperatorService, StubCatalogService} from './StubServer';
+import { StubService, StubAbnormalService, StubAccessControlService, StubOperatorService, StubCatalogService, BookOperateResponseService } from './StubServer';
 
 /* eslint-enable */
 
@@ -29,6 +29,7 @@ const _errorServer = new StubAbnormalService(5555, '/service-C');
 const _mockAccessControl = new StubAccessControlService();
 const _mockOperatorService = new StubOperatorService();
 const _mockCatalogService = new StubCatalogService();
+const _mockBookOperateService = new BookOperateResponseService(3006, 0);
 
 // PXR-Block-Proxy Service APIのユニットテスト
 describe('PXR-Block-Proxy Service API', () => {
@@ -49,6 +50,9 @@ describe('PXR-Block-Proxy Service API', () => {
         _mockAccessControl.server.close();
         _mockOperatorService.server.close();
         _mockCatalogService.server.close();
+        if (_mockBookOperateService) {
+            _mockBookOperateService.server.close();
+        }
 
         // 元のファイル状態に変更する
         fs.writeFileSync('./config/port.json', beforeFileLines);
@@ -785,6 +789,1039 @@ describe('PXR-Block-Proxy Service API', () => {
             // Expect status Success code.
             expect(JSON.stringify(response.body)).toBe(JSON.stringify({}));
             expect(response.status).toBe(200);
+        });
+
+        // POSTリバースプロキシー
+        describe('SNS通知バグ対応追加ケース)', () => {
+            test('正常系: POST 共有のレスポンスに共有が許可されていないドキュメントが含まれていた場合にフィルタされることの確認', async () => {
+                const response = await supertest(expressApp)
+                    .post(baseURI)
+                    .set('Cookie', ['operator_type2_session=8947a6a73a6c8f952fe73678d84c2684892921bbdbd3a10fe910a7a8d3bb5aa5'])
+                    .query({
+                        block: 5555555,
+                        from_block: 3333333,
+                        path: encodeURIComponent('/book-operate/share/search'),
+                        from_path: encodeURIComponent('/book-operate/share_1')
+                    })
+                    .set({
+                        'Content-Type': 'application/json',
+                        accept: 'application/json'
+                    });
+                // ドキュメントがフィルタされていることの確認
+                expect(JSON.stringify(response.body)).toBe(JSON.stringify({
+                    document: [],
+                    event: [
+                        {
+                            id: {
+                                index: '3_1_1',
+                                value: 'doc01-eve01-8eb5-9b57-ac1980208f21'
+                            },
+                            code: {
+                                index: '3_1_2',
+                                value: {
+                                    _value: 1000811,
+                                    _ver: 1
+                                }
+                            },
+                            start: {
+                                index: '3_2_1',
+                                value: '2020-02-20 00:00:00'
+                            },
+                            end: {
+                                index: '3_2_2',
+                                value: '2020-02-21 00:00:00'
+                            },
+                            location: {
+                                index: '3_3_1',
+                                value: 'location'
+                            },
+                            sourceId: '20200221-1',
+                            env: null,
+                            wf: null,
+                            app: {
+                                code: {
+                                    index: '3_5_1',
+                                    value: {
+                                        _value: 1000438,
+                                        _ver: 1
+                                    }
+                                },
+                                app: {
+                                    index: '3_5_5',
+                                    value: {
+                                        _value: 1000481,
+                                        _ver: 1
+                                    }
+                                }
+                            },
+                            thing: [
+                                {
+                                    acquired_time: {
+                                        index: '4_2_2_4',
+                                        value: null
+                                    },
+                                    code: {
+                                        index: '4_1_2',
+                                        value: {
+                                            _value: 1000814,
+                                            _ver: 1
+                                        }
+                                    },
+                                    env: null,
+                                    sourceId: '20200221-1',
+                                    id: {
+                                        index: '4_1_1',
+                                        value: 'doc01-eve01-thi01-c4e0-130b2788dcf4'
+                                    },
+                                    wf: null,
+                                    app: {
+                                        code: {
+                                            index: '3_5_1',
+                                            value: {
+                                                _value: 1000438,
+                                                _ver: 1
+                                            }
+                                        },
+                                        app: {
+                                            index: '3_5_5',
+                                            value: {
+                                                _value: 1000481,
+                                                _ver: 1
+                                            }
+                                        }
+                                    },
+                                    'x-axis': {
+                                        index: '4_2_2_1',
+                                        value: null
+                                    },
+                                    'y-axis': {
+                                        index: '4_2_2_2',
+                                        value: null
+                                    },
+                                    'z-axis': {
+                                        index: '4_2_2_3',
+                                        value: null
+                                    }
+                                },
+                                {
+                                    acquired_time: {
+                                        index: '4_2_2_4',
+                                        value: null
+                                    },
+                                    code: {
+                                        index: '4_1_2',
+                                        value: {
+                                            _value: 1000815,
+                                            _ver: 1
+                                        }
+                                    },
+                                    env: null,
+                                    sourceId: '20200221-1',
+                                    id: {
+                                        index: '4_1_1',
+                                        value: 'doc01-eve01-thi01-1171a3b52499'
+                                    },
+                                    wf: null,
+                                    app: {
+                                        code: {
+                                            index: '3_5_1',
+                                            value: {
+                                                _value: 1000438,
+                                                _ver: 1
+                                            }
+                                        },
+                                        app: {
+                                            index: '3_5_5',
+                                            value: {
+                                                _value: 1000481,
+                                                _ver: 1
+                                            }
+                                        }
+                                    },
+                                    'x-axis': {
+                                        index: '4_2_2_1',
+                                        value: null
+                                    },
+                                    'y-axis': {
+                                        index: '4_2_2_2',
+                                        value: null
+                                    },
+                                    'z-axis': {
+                                        index: '4_2_2_3',
+                                        value: null
+                                    }
+                                }
+                            ]
+                        }
+                    ],
+                    thing: [
+                        {
+                            acquired_time: {
+                                index: '4_2_2_4',
+                                value: null
+                            },
+                            code: {
+                                index: '4_1_2',
+                                value: {
+                                    _value: 1000818,
+                                    _ver: 1
+                                }
+                            },
+                            env: null,
+                            sourceId: '20200221-1',
+                            id: {
+                                index: '4_1_1',
+                                value: 'doc01-eve01-thi01-c4e0-130b2788dcf4'
+                            },
+                            wf: null,
+                            app: {
+                                code: {
+                                    index: '3_5_1',
+                                    value: {
+                                        _value: 1000438,
+                                        _ver: 1
+                                    }
+                                },
+                                app: {
+                                    index: '3_5_5',
+                                    value: {
+                                        _value: 1000481,
+                                        _ver: 1
+                                    }
+                                }
+                            },
+                            'x-axis': {
+                                index: '4_2_2_1',
+                                value: null
+                            },
+                            'y-axis': {
+                                index: '4_2_2_2',
+                                value: null
+                            },
+                            'z-axis': {
+                                index: '4_2_2_3',
+                                value: null
+                            }
+                        }
+                    ]
+                }));
+                expect(response.status).toBe(200);
+            });
+
+            test('正常系: POST 共有のレスポンスに共有が許可されていないイベントが含まれていた場合にフィルタされることの確認', async () => {
+                const response = await supertest(expressApp)
+                    .post(baseURI)
+                    .set('Cookie', ['operator_type2_session=8947a6a73a6c8f952fe73678d84c2684892921bbdbd3a10fe910a7a8d3bb5aa5'])
+                    .query({
+                        block: 5555555,
+                        from_block: 3333333,
+                        path: encodeURIComponent('/book-operate/share/search'),
+                        from_path: encodeURIComponent('/book-operate/share_2')
+                    })
+                    .set({
+                        'Content-Type': 'application/json',
+                        accept: 'application/json'
+                    });
+                // イベントがフィルタされていることの確認
+                expect(JSON.stringify(response.body)).toBe(JSON.stringify({
+                    document: [
+                        {
+                            id: {
+                                index: '2_1_1',
+                                value: 'doc01-89bb-f8f2-74a0-dc517da60653'
+                            },
+                            code: {
+                                index: '2_1_2',
+                                value: {
+                                    _value: 1001010,
+                                    _ver: 1
+                                }
+                            },
+                            createdAt: {
+                                index: '2_2_1',
+                                value: '2020-02-20 00:00:00'
+                            },
+                            sourceId: '20200221-1',
+                            wf: null,
+                            app: {
+                                code: {
+                                    index: '2_3_1',
+                                    value: {
+                                        _value: 1000438,
+                                        _ver: 1
+                                    }
+                                },
+                                app: {
+                                    index: '2_3_5',
+                                    value: {
+                                        _value: 1000481,
+                                        _ver: 1
+                                    }
+                                },
+                                staffId: {
+                                    index: '2_3_4',
+                                    value: 'staffId'
+                                }
+                            },
+                            chapter: [
+                                {
+                                    title: 'タイトル１',
+                                    event: [
+                                        'doc01-eve01-8eb5-9b57-ac1980208f21',
+                                        'doc01-eve02-e230-930c-c43d5050b9d3'
+                                    ]
+                                }
+                            ]
+                        }
+                    ],
+                    event: [],
+                    thing: [
+                        {
+                            acquired_time: {
+                                index: '4_2_2_4',
+                                value: null
+                            },
+                            code: {
+                                index: '4_1_2',
+                                value: {
+                                    _value: 1000818,
+                                    _ver: 1
+                                }
+                            },
+                            env: null,
+                            sourceId: '20200221-1',
+                            id: {
+                                index: '4_1_1',
+                                value: 'doc01-eve01-thi01-c4e0-130b2788dcf4'
+                            },
+                            wf: null,
+                            app: {
+                                code: {
+                                    index: '3_5_1',
+                                    value: {
+                                        _value: 1000438,
+                                        _ver: 1
+                                    }
+                                },
+                                app: {
+                                    index: '3_5_5',
+                                    value: {
+                                        _value: 1000481,
+                                        _ver: 1
+                                    }
+                                }
+                            },
+                            'x-axis': {
+                                index: '4_2_2_1',
+                                value: null
+                            },
+                            'y-axis': {
+                                index: '4_2_2_2',
+                                value: null
+                            },
+                            'z-axis': {
+                                index: '4_2_2_3',
+                                value: null
+                            }
+                        }
+                    ]
+                }));
+                expect(response.status).toBe(200);
+            });
+
+            test('正常系: POST 共有のレスポンスに共有が許可されていないモノが含まれていた場合にフィルタされることの確認', async () => {
+                const response = await supertest(expressApp)
+                    .post(baseURI)
+                    .set('Cookie', ['operator_type2_session=8947a6a73a6c8f952fe73678d84c2684892921bbdbd3a10fe910a7a8d3bb5aa5'])
+                    .query({
+                        block: 5555555,
+                        from_block: 3333333,
+                        path: encodeURIComponent('/book-operate/share/search'),
+                        from_path: encodeURIComponent('/book-operate/share_3')
+                    })
+                    .set({
+                        'Content-Type': 'application/json',
+                        accept: 'application/json'
+                    });
+                // モノがフィルタされていることの確認
+                expect(JSON.stringify(response.body)).toBe(JSON.stringify({
+                    document: [
+                        {
+                            id: {
+                                index: '2_1_1',
+                                value: 'doc01-89bb-f8f2-74a0-dc517da60653'
+                            },
+                            code: {
+                                index: '2_1_2',
+                                value: {
+                                    _value: 1001010,
+                                    _ver: 1
+                                }
+                            },
+                            createdAt: {
+                                index: '2_2_1',
+                                value: '2020-02-20 00:00:00'
+                            },
+                            sourceId: '20200221-1',
+                            wf: null,
+                            app: {
+                                code: {
+                                    index: '2_3_1',
+                                    value: {
+                                        _value: 1000438,
+                                        _ver: 1
+                                    }
+                                },
+                                app: {
+                                    index: '2_3_5',
+                                    value: {
+                                        _value: 1000481,
+                                        _ver: 1
+                                    }
+                                },
+                                staffId: {
+                                    index: '2_3_4',
+                                    value: 'staffId'
+                                }
+                            },
+                            chapter: [
+                                {
+                                    title: 'タイトル１',
+                                    event: [
+                                        'doc01-eve01-8eb5-9b57-ac1980208f21',
+                                        'doc01-eve02-e230-930c-c43d5050b9d3'
+                                    ]
+                                }
+                            ]
+                        }
+                    ],
+                    event: [
+                        {
+                            id: {
+                                index: '3_1_1',
+                                value: 'doc01-eve01-8eb5-9b57-ac1980208f21'
+                            },
+                            code: {
+                                index: '3_1_2',
+                                value: {
+                                    _value: 1000811,
+                                    _ver: 1
+                                }
+                            },
+                            start: {
+                                index: '3_2_1',
+                                value: '2020-02-20 00:00:00'
+                            },
+                            end: {
+                                index: '3_2_2',
+                                value: '2020-02-21 00:00:00'
+                            },
+                            location: {
+                                index: '3_3_1',
+                                value: 'location'
+                            },
+                            sourceId: '20200221-1',
+                            env: null,
+                            wf: null,
+                            app: {
+                                code: {
+                                    index: '3_5_1',
+                                    value: {
+                                        _value: 1000438,
+                                        _ver: 1
+                                    }
+                                },
+                                app: {
+                                    index: '3_5_5',
+                                    value: {
+                                        _value: 1000481,
+                                        _ver: 1
+                                    }
+                                }
+                            },
+                            thing: [
+                                {
+                                    acquired_time: {
+                                        index: '4_2_2_4',
+                                        value: null
+                                    },
+                                    code: {
+                                        index: '4_1_2',
+                                        value: {
+                                            _value: 1000814,
+                                            _ver: 1
+                                        }
+                                    },
+                                    env: null,
+                                    sourceId: '20200221-1',
+                                    id: {
+                                        index: '4_1_1',
+                                        value: 'doc01-eve01-thi01-c4e0-130b2788dcf4'
+                                    },
+                                    wf: null,
+                                    app: {
+                                        code: {
+                                            index: '3_5_1',
+                                            value: {
+                                                _value: 1000438,
+                                                _ver: 1
+                                            }
+                                        },
+                                        app: {
+                                            index: '3_5_5',
+                                            value: {
+                                                _value: 1000481,
+                                                _ver: 1
+                                            }
+                                        }
+                                    },
+                                    'x-axis': {
+                                        index: '4_2_2_1',
+                                        value: null
+                                    },
+                                    'y-axis': {
+                                        index: '4_2_2_2',
+                                        value: null
+                                    },
+                                    'z-axis': {
+                                        index: '4_2_2_3',
+                                        value: null
+                                    }
+                                },
+                                {
+                                    acquired_time: {
+                                        index: '4_2_2_4',
+                                        value: null
+                                    },
+                                    code: {
+                                        index: '4_1_2',
+                                        value: {
+                                            _value: 1000815,
+                                            _ver: 1
+                                        }
+                                    },
+                                    env: null,
+                                    sourceId: '20200221-1',
+                                    id: {
+                                        index: '4_1_1',
+                                        value: 'doc01-eve01-thi01-1171a3b52499'
+                                    },
+                                    wf: null,
+                                    app: {
+                                        code: {
+                                            index: '3_5_1',
+                                            value: {
+                                                _value: 1000438,
+                                                _ver: 1
+                                            }
+                                        },
+                                        app: {
+                                            index: '3_5_5',
+                                            value: {
+                                                _value: 1000481,
+                                                _ver: 1
+                                            }
+                                        }
+                                    },
+                                    'x-axis': {
+                                        index: '4_2_2_1',
+                                        value: null
+                                    },
+                                    'y-axis': {
+                                        index: '4_2_2_2',
+                                        value: null
+                                    },
+                                    'z-axis': {
+                                        index: '4_2_2_3',
+                                        value: null
+                                    }
+                                }
+                            ]
+                        }
+                    ],
+                    thing: []
+                }));
+                expect(response.status).toBe(200);
+            });
+
+            test('正常系: POST 共有のレスポンスのイベント配下に共有が許可されていないモノが含まれていた場合にフィルタされることの確認', async () => {
+                const response = await supertest(expressApp)
+                    .post(baseURI)
+                    .set('Cookie', ['operator_type2_session=8947a6a73a6c8f952fe73678d84c2684892921bbdbd3a10fe910a7a8d3bb5aa5'])
+                    .query({
+                        block: 5555555,
+                        from_block: 3333333,
+                        path: encodeURIComponent('/book-operate/share/search'),
+                        from_path: encodeURIComponent('/book-operate/share_4')
+                    })
+                    .set({
+                        'Content-Type': 'application/json',
+                        accept: 'application/json'
+                    });
+                // イベント配下のモノがフィルタされていることの確認
+                expect(JSON.stringify(response.body)).toBe(JSON.stringify({
+                    document: [
+                        {
+                            id: {
+                                index: '2_1_1',
+                                value: 'doc01-89bb-f8f2-74a0-dc517da60653'
+                            },
+                            code: {
+                                index: '2_1_2',
+                                value: {
+                                    _value: 1001010,
+                                    _ver: 1
+                                }
+                            },
+                            createdAt: {
+                                index: '2_2_1',
+                                value: '2020-02-20 00:00:00'
+                            },
+                            sourceId: '20200221-1',
+                            wf: null,
+                            app: {
+                                code: {
+                                    index: '2_3_1',
+                                    value: {
+                                        _value: 1000438,
+                                        _ver: 1
+                                    }
+                                },
+                                app: {
+                                    index: '2_3_5',
+                                    value: {
+                                        _value: 1000481,
+                                        _ver: 1
+                                    }
+                                },
+                                staffId: {
+                                    index: '2_3_4',
+                                    value: 'staffId'
+                                }
+                            },
+                            chapter: [
+                                {
+                                    title: 'タイトル１',
+                                    event: [
+                                        'doc01-eve01-8eb5-9b57-ac1980208f21',
+                                        'doc01-eve02-e230-930c-c43d5050b9d3'
+                                    ]
+                                }
+                            ]
+                        }
+                    ],
+                    event: [
+                        {
+                            id: {
+                                index: '3_1_1',
+                                value: 'doc01-eve01-8eb5-9b57-ac1980208f21'
+                            },
+                            code: {
+                                index: '3_1_2',
+                                value: {
+                                    _value: 1000811,
+                                    _ver: 1
+                                }
+                            },
+                            start: {
+                                index: '3_2_1',
+                                value: '2020-02-20 00:00:00'
+                            },
+                            end: {
+                                index: '3_2_2',
+                                value: '2020-02-21 00:00:00'
+                            },
+                            location: {
+                                index: '3_3_1',
+                                value: 'location'
+                            },
+                            sourceId: '20200221-1',
+                            env: null,
+                            wf: null,
+                            app: {
+                                code: {
+                                    index: '3_5_1',
+                                    value: {
+                                        _value: 1000438,
+                                        _ver: 1
+                                    }
+                                },
+                                app: {
+                                    index: '3_5_5',
+                                    value: {
+                                        _value: 1000481,
+                                        _ver: 1
+                                    }
+                                }
+                            },
+                            thing: [
+                                {
+                                    acquired_time: {
+                                        index: '4_2_2_4',
+                                        value: null
+                                    },
+                                    code: {
+                                        index: '4_1_2',
+                                        value: {
+                                            _value: 1000814,
+                                            _ver: 1
+                                        }
+                                    },
+                                    env: null,
+                                    sourceId: '20200221-1',
+                                    id: {
+                                        index: '4_1_1',
+                                        value: 'doc01-eve01-thi01-c4e0-130b2788dcf4'
+                                    },
+                                    wf: null,
+                                    app: {
+                                        code: {
+                                            index: '3_5_1',
+                                            value: {
+                                                _value: 1000438,
+                                                _ver: 1
+                                            }
+                                        },
+                                        app: {
+                                            index: '3_5_5',
+                                            value: {
+                                                _value: 1000481,
+                                                _ver: 1
+                                            }
+                                        }
+                                    },
+                                    'x-axis': {
+                                        index: '4_2_2_1',
+                                        value: null
+                                    },
+                                    'y-axis': {
+                                        index: '4_2_2_2',
+                                        value: null
+                                    },
+                                    'z-axis': {
+                                        index: '4_2_2_3',
+                                        value: null
+                                    }
+                                }
+                            ]
+                        }
+                    ],
+                    thing: [
+                        {
+                            acquired_time: {
+                                index: '4_2_2_4',
+                                value: null
+                            },
+                            code: {
+                                index: '4_1_2',
+                                value: {
+                                    _value: 1000818,
+                                    _ver: 1
+                                }
+                            },
+                            env: null,
+                            sourceId: '20200221-1',
+                            id: {
+                                index: '4_1_1',
+                                value: 'doc01-eve01-thi01-c4e0-130b2788dcf4'
+                            },
+                            wf: null,
+                            app: {
+                                code: {
+                                    index: '3_5_1',
+                                    value: {
+                                        _value: 1000438,
+                                        _ver: 1
+                                    }
+                                },
+                                app: {
+                                    index: '3_5_5',
+                                    value: {
+                                        _value: 1000481,
+                                        _ver: 1
+                                    }
+                                }
+                            },
+                            'x-axis': {
+                                index: '4_2_2_1',
+                                value: null
+                            },
+                            'y-axis': {
+                                index: '4_2_2_2',
+                                value: null
+                            },
+                            'z-axis': {
+                                index: '4_2_2_3',
+                                value: null
+                            }
+                        }
+                    ]
+                }));
+                expect(response.status).toBe(200);
+            });
+
+            test('正常系: POST アクセス制御サービスから取得したフィルタ情報がJSON形式でない場合、フィルタされないことを確認', async () => {
+                const response = await supertest(expressApp)
+                    .post(baseURI)
+                    .set('Cookie', ['operator_type2_session=8947a6a73a6c8f952fe73678d84c2684892921bbdbd3a10fe910a7a8d3bb5aa5'])
+                    .query({
+                        block: 5555555,
+                        from_block: 3333333,
+                        path: encodeURIComponent('/book-operate/share/search'),
+                        from_path: encodeURIComponent('/book-operate/share_5')
+                    })
+                    .set({
+                        'Content-Type': 'application/json',
+                        accept: 'application/json'
+                    });
+                // イベント配下のモノがフィルタされていないことの確認
+                expect(JSON.stringify(response.body)).toBe(JSON.stringify({
+                    document: [
+                        {
+                            id: {
+                                index: '2_1_1',
+                                value: 'doc01-89bb-f8f2-74a0-dc517da60653'
+                            },
+                            code: {
+                                index: '2_1_2',
+                                value: {
+                                    _value: 1001010,
+                                    _ver: 1
+                                }
+                            },
+                            createdAt: {
+                                index: '2_2_1',
+                                value: '2020-02-20 00:00:00'
+                            },
+                            sourceId: '20200221-1',
+                            wf: null,
+                            app: {
+                                code: {
+                                    index: '2_3_1',
+                                    value: {
+                                        _value: 1000438,
+                                        _ver: 1
+                                    }
+                                },
+                                app: {
+                                    index: '2_3_5',
+                                    value: {
+                                        _value: 1000481,
+                                        _ver: 1
+                                    }
+                                },
+                                staffId: {
+                                    index: '2_3_4',
+                                    value: 'staffId'
+                                }
+                            },
+                            chapter: [
+                                {
+                                    title: 'タイトル１',
+                                    event: [
+                                        'doc01-eve01-8eb5-9b57-ac1980208f21',
+                                        'doc01-eve02-e230-930c-c43d5050b9d3'
+                                    ]
+                                }
+                            ]
+                        }
+                    ],
+                    event: [
+                        {
+                            id: {
+                                index: '3_1_1',
+                                value: 'doc01-eve01-8eb5-9b57-ac1980208f21'
+                            },
+                            code: {
+                                index: '3_1_2',
+                                value: {
+                                    _value: 1000811,
+                                    _ver: 1
+                                }
+                            },
+                            start: {
+                                index: '3_2_1',
+                                value: '2020-02-20 00:00:00'
+                            },
+                            end: {
+                                index: '3_2_2',
+                                value: '2020-02-21 00:00:00'
+                            },
+                            location: {
+                                index: '3_3_1',
+                                value: 'location'
+                            },
+                            sourceId: '20200221-1',
+                            env: null,
+                            wf: null,
+                            app: {
+                                code: {
+                                    index: '3_5_1',
+                                    value: {
+                                        _value: 1000438,
+                                        _ver: 1
+                                    }
+                                },
+                                app: {
+                                    index: '3_5_5',
+                                    value: {
+                                        _value: 1000481,
+                                        _ver: 1
+                                    }
+                                }
+                            },
+                            thing: [
+                                {
+                                    acquired_time: {
+                                        index: '4_2_2_4',
+                                        value: null
+                                    },
+                                    code: {
+                                        index: '4_1_2',
+                                        value: {
+                                            _value: 1000814,
+                                            _ver: 1
+                                        }
+                                    },
+                                    env: null,
+                                    sourceId: '20200221-1',
+                                    id: {
+                                        index: '4_1_1',
+                                        value: 'doc01-eve01-thi01-c4e0-130b2788dcf4'
+                                    },
+                                    wf: null,
+                                    app: {
+                                        code: {
+                                            index: '3_5_1',
+                                            value: {
+                                                _value: 1000438,
+                                                _ver: 1
+                                            }
+                                        },
+                                        app: {
+                                            index: '3_5_5',
+                                            value: {
+                                                _value: 1000481,
+                                                _ver: 1
+                                            }
+                                        }
+                                    },
+                                    'x-axis': {
+                                        index: '4_2_2_1',
+                                        value: null
+                                    },
+                                    'y-axis': {
+                                        index: '4_2_2_2',
+                                        value: null
+                                    },
+                                    'z-axis': {
+                                        index: '4_2_2_3',
+                                        value: null
+                                    }
+                                },
+                                {
+                                    acquired_time: {
+                                        index: '4_2_2_4',
+                                        value: null
+                                    },
+                                    code: {
+                                        index: '4_1_2',
+                                        value: {
+                                            _value: 1000815,
+                                            _ver: 1
+                                        }
+                                    },
+                                    env: null,
+                                    sourceId: '20200221-1',
+                                    id: {
+                                        index: '4_1_1',
+                                        value: 'doc01-eve01-thi01-1171a3b52499'
+                                    },
+                                    wf: null,
+                                    app: {
+                                        code: {
+                                            index: '3_5_1',
+                                            value: {
+                                                _value: 1000438,
+                                                _ver: 1
+                                            }
+                                        },
+                                        app: {
+                                            index: '3_5_5',
+                                            value: {
+                                                _value: 1000481,
+                                                _ver: 1
+                                            }
+                                        }
+                                    },
+                                    'x-axis': {
+                                        index: '4_2_2_1',
+                                        value: null
+                                    },
+                                    'y-axis': {
+                                        index: '4_2_2_2',
+                                        value: null
+                                    },
+                                    'z-axis': {
+                                        index: '4_2_2_3',
+                                        value: null
+                                    }
+                                }
+                            ]
+                        }
+                    ],
+                    thing: [
+                        {
+                            acquired_time: {
+                                index: '4_2_2_4',
+                                value: null
+                            },
+                            code: {
+                                index: '4_1_2',
+                                value: {
+                                    _value: 1000818,
+                                    _ver: 1
+                                }
+                            },
+                            env: null,
+                            sourceId: '20200221-1',
+                            id: {
+                                index: '4_1_1',
+                                value: 'doc01-eve01-thi01-c4e0-130b2788dcf4'
+                            },
+                            wf: null,
+                            app: {
+                                code: {
+                                    index: '3_5_1',
+                                    value: {
+                                        _value: 1000438,
+                                        _ver: 1
+                                    }
+                                },
+                                app: {
+                                    index: '3_5_5',
+                                    value: {
+                                        _value: 1000481,
+                                        _ver: 1
+                                    }
+                                }
+                            },
+                            'x-axis': {
+                                index: '4_2_2_1',
+                                value: null
+                            },
+                            'y-axis': {
+                                index: '4_2_2_2',
+                                value: null
+                            },
+                            'z-axis': {
+                                index: '4_2_2_3',
+                                value: null
+                            }
+                        }
+                    ]
+                }));
+            });
         });
     });
 });

--- a/src/tests/StubServer.ts
+++ b/src/tests/StubServer.ts
@@ -7,6 +7,7 @@ import fs = require('fs');
 import express = require('express');
 import request = require('request');
 import { Server } from 'net';
+import bodyParser = require('body-parser');
 /* eslint-enable */
 
 /** テスト用サーバー（宛先サービス） */
@@ -45,6 +46,423 @@ export class BinaryResponseService {
     }
 }
 
+export class BookOperateResponseService {
+    app: express.Express;
+    server: Server;
+
+    constructor (port: number, type: number) {
+        this.app = express();
+        const shareHandler = (req: express.Request, res: express.Response) => {
+            if (type === 0) {
+                res.status(200).json({
+                    document: [
+                        {
+                            id: {
+                                index: '2_1_1',
+                                value: 'doc01-89bb-f8f2-74a0-dc517da60653'
+                            },
+                            code: {
+                                index: '2_1_2',
+                                value: {
+                                    _value: 1001010,
+                                    _ver: 1
+                                }
+                            },
+                            createdAt: {
+                                index: '2_2_1',
+                                value: '2020-02-20 00:00:00'
+                            },
+                            sourceId: '20200221-1',
+                            wf: null,
+                            app: {
+                                code: {
+                                    index: '2_3_1',
+                                    value: {
+                                        _value: 1000438,
+                                        _ver: 1
+                                    }
+                                },
+                                app: {
+                                    index: '2_3_5',
+                                    value: {
+                                        _value: 1000481,
+                                        _ver: 1
+                                    }
+                                },
+                                staffId: {
+                                    index: '2_3_4',
+                                    value: 'staffId'
+                                }
+                            },
+                            chapter: [
+                                {
+                                    title: 'タイトル１',
+                                    event: [
+                                        'doc01-eve01-8eb5-9b57-ac1980208f21',
+                                        'doc01-eve02-e230-930c-c43d5050b9d3'
+                                    ]
+                                }
+                            ]
+                        }
+                    ],
+                    event: [
+                        {
+                            id: {
+                                index: '3_1_1',
+                                value: 'doc01-eve01-8eb5-9b57-ac1980208f21'
+                            },
+                            code: {
+                                index: '3_1_2',
+                                value: {
+                                    _value: 1000811,
+                                    _ver: 1
+                                }
+                            },
+                            start: {
+                                index: '3_2_1',
+                                value: '2020-02-20 00:00:00'
+                            },
+                            end: {
+                                index: '3_2_2',
+                                value: '2020-02-21 00:00:00'
+                            },
+                            location: {
+                                index: '3_3_1',
+                                value: 'location'
+                            },
+                            sourceId: '20200221-1',
+                            env: null,
+                            wf: null,
+                            app: {
+                                code: {
+                                    index: '3_5_1',
+                                    value: {
+                                        _value: 1000438,
+                                        _ver: 1
+                                    }
+                                },
+                                app: {
+                                    index: '3_5_5',
+                                    value: {
+                                        _value: 1000481,
+                                        _ver: 1
+                                    }
+                                }
+                            },
+                            thing: [
+                                {
+                                    acquired_time: {
+                                        index: '4_2_2_4',
+                                        value: null
+                                    },
+                                    code: {
+                                        index: '4_1_2',
+                                        value: {
+                                            _value: 1000814,
+                                            _ver: 1
+                                        }
+                                    },
+                                    env: null,
+                                    sourceId: '20200221-1',
+                                    id: {
+                                        index: '4_1_1',
+                                        value: 'doc01-eve01-thi01-c4e0-130b2788dcf4'
+                                    },
+                                    wf: null,
+                                    app: {
+                                        code: {
+                                            index: '3_5_1',
+                                            value: {
+                                                _value: 1000438,
+                                                _ver: 1
+                                            }
+                                        },
+                                        app: {
+                                            index: '3_5_5',
+                                            value: {
+                                                _value: 1000481,
+                                                _ver: 1
+                                            }
+                                        }
+                                    },
+                                    'x-axis': {
+                                        index: '4_2_2_1',
+                                        value: null
+                                    },
+                                    'y-axis': {
+                                        index: '4_2_2_2',
+                                        value: null
+                                    },
+                                    'z-axis': {
+                                        index: '4_2_2_3',
+                                        value: null
+                                    }
+                                },
+                                {
+                                    acquired_time: {
+                                        index: '4_2_2_4',
+                                        value: null
+                                    },
+                                    code: {
+                                        index: '4_1_2',
+                                        value: {
+                                            _value: 1000815,
+                                            _ver: 1
+                                        }
+                                    },
+                                    env: null,
+                                    sourceId: '20200221-1',
+                                    id: {
+                                        index: '4_1_1',
+                                        value: 'doc01-eve01-thi01-1171a3b52499'
+                                    },
+                                    wf: null,
+                                    app: {
+                                        code: {
+                                            index: '3_5_1',
+                                            value: {
+                                                _value: 1000438,
+                                                _ver: 1
+                                            }
+                                        },
+                                        app: {
+                                            index: '3_5_5',
+                                            value: {
+                                                _value: 1000481,
+                                                _ver: 1
+                                            }
+                                        }
+                                    },
+                                    'x-axis': {
+                                        index: '4_2_2_1',
+                                        value: null
+                                    },
+                                    'y-axis': {
+                                        index: '4_2_2_2',
+                                        value: null
+                                    },
+                                    'z-axis': {
+                                        index: '4_2_2_3',
+                                        value: null
+                                    }
+                                }
+                            ]
+                        }
+                    ],
+                    thing: [
+                        {
+                            acquired_time: {
+                                index: '4_2_2_4',
+                                value: null
+                            },
+                            code: {
+                                index: '4_1_2',
+                                value: {
+                                    _value: 1000818,
+                                    _ver: 1
+                                }
+                            },
+                            env: null,
+                            sourceId: '20200221-1',
+                            id: {
+                                index: '4_1_1',
+                                value: 'doc01-eve01-thi01-c4e0-130b2788dcf4'
+                            },
+                            wf: null,
+                            app: {
+                                code: {
+                                    index: '3_5_1',
+                                    value: {
+                                        _value: 1000438,
+                                        _ver: 1
+                                    }
+                                },
+                                app: {
+                                    index: '3_5_5',
+                                    value: {
+                                        _value: 1000481,
+                                        _ver: 1
+                                    }
+                                }
+                            },
+                            'x-axis': {
+                                index: '4_2_2_1',
+                                value: null
+                            },
+                            'y-axis': {
+                                index: '4_2_2_2',
+                                value: null
+                            },
+                            'z-axis': {
+                                index: '4_2_2_3',
+                                value: null
+                            }
+                        }
+                    ]
+                });
+            } else if (type === 1) {
+                res.status(200).json({
+                    document: [
+                        {
+                            id: {
+                                index: '2_1_1',
+                                value: 'doc01-89bb-f8f2-74a0-dc517da60653'
+                            },
+                            code: {
+                                index: '2_1_2',
+                                value: {
+                                    _value: 1001010,
+                                    _ver: 1
+                                }
+                            },
+                            createdAt: {
+                                index: '2_2_1',
+                                value: '2020-02-20 00:00:00'
+                            },
+                            sourceId: '20200221-1',
+                            wf: null,
+                            app: {
+                                code: {
+                                    index: '2_3_1',
+                                    value: {
+                                        _value: 1000438,
+                                        _ver: 1
+                                    }
+                                },
+                                app: {
+                                    index: '2_3_5',
+                                    value: {
+                                        _value: 1000481,
+                                        _ver: 1
+                                    }
+                                },
+                                staffId: {
+                                    index: '2_3_4',
+                                    value: 'staffId'
+                                }
+                            },
+                            chapter: [
+                                {
+                                    title: 'タイトル１',
+                                    event: [
+                                        'doc01-eve01-8eb5-9b57-ac1980208f21',
+                                        'doc01-eve02-e230-930c-c43d5050b9d3'
+                                    ]
+                                }
+                            ]
+                        }
+                    ],
+                    event: [
+                        {
+                            id: {
+                                index: '3_1_1',
+                                value: 'doc01-eve01-8eb5-9b57-ac1980208f21'
+                            },
+                            code: {
+                                index: '3_1_2',
+                                value: {
+                                    _value: 1000811,
+                                    _ver: 1
+                                }
+                            },
+                            start: {
+                                index: '3_2_1',
+                                value: '2020-02-20 00:00:00'
+                            },
+                            end: {
+                                index: '3_2_2',
+                                value: '2020-02-21 00:00:00'
+                            },
+                            location: {
+                                index: '3_3_1',
+                                value: 'location'
+                            },
+                            sourceId: '20200221-1',
+                            env: null,
+                            wf: null,
+                            app: {
+                                code: {
+                                    index: '3_5_1',
+                                    value: {
+                                        _value: 1000438,
+                                        _ver: 1
+                                    }
+                                },
+                                app: {
+                                    index: '3_5_5',
+                                    value: {
+                                        _value: 1000481,
+                                        _ver: 1
+                                    }
+                                }
+                            },
+                            thing: null
+                        }
+                    ],
+                    thing: [
+                        {
+                            acquired_time: {
+                                index: '4_2_2_4',
+                                value: null
+                            },
+                            code: {
+                                index: '4_1_2',
+                                value: {
+                                    _value: 1000818,
+                                    _ver: 1
+                                }
+                            },
+                            env: null,
+                            sourceId: '20200221-1',
+                            id: {
+                                index: '4_1_1',
+                                value: 'doc01-eve01-thi01-c4e0-130b2788dcf4'
+                            },
+                            wf: null,
+                            app: {
+                                code: {
+                                    index: '3_5_1',
+                                    value: {
+                                        _value: 1000438,
+                                        _ver: 1
+                                    }
+                                },
+                                app: {
+                                    index: '3_5_5',
+                                    value: {
+                                        _value: 1000481,
+                                        _ver: 1
+                                    }
+                                }
+                            },
+                            'x-axis': {
+                                index: '4_2_2_1',
+                                value: null
+                            },
+                            'y-axis': {
+                                index: '4_2_2_2',
+                                value: null
+                            },
+                            'z-axis': {
+                                index: '4_2_2_3',
+                                value: null
+                            }
+                        }
+                    ]
+                });
+            } else if (type === 2) {
+                res.status(200).json({
+                    document: [],
+                    event: [],
+                    thing: []
+                });
+            }
+        };
+        this.app.post('/book-operate/share/search', shareHandler);
+        this.server = this.app.listen(port);
+    }
+}
+
 /** テスト用異常サーバー（宛先サービス） */
 export class StubAbnormalService {
     app: express.Express;
@@ -70,6 +488,7 @@ export class StubAccessControlService {
 
     constructor () {
         this.app = express();
+        this.app.use(bodyParser.json({ limit: '50mb' }));
         this.app.post('/access-control/token', (req: express.Request, res: express.Response) => {
             res.status(200).json([{
                 apiToken: 'b4ee2feb1251b8e2998ce0c47ccf31542d4416f4967f157b3f35534a9352216c',
@@ -77,7 +496,18 @@ export class StubAccessControlService {
             }]);
         });
         this.app.post('/access-control/collate', (req: express.Request, res: express.Response) => {
-            res.status(200).json();
+            const apiUrl = req.body.caller.apiUrl;
+            if (apiUrl === '/book-operate/share_1') {
+                res.status(200).json({ userId: 'test_user_id', parameter: '{"document":[],"event":[{"_value":1000811,"_ver":1}],"thing":[{"_value":1000814,"_ver":1},{"_value":1000815,"_ver":1},{"_value":1000818,"_ver":1}]}' });
+            } else if (apiUrl === '/book-operate/share_2') {
+                res.status(200).json({ userId: 'test_user_id', parameter: '{"document":[{"_value":1001010,"_ver":1}],"event":[],"thing":[{"_value":1000814,"_ver":1},{"_value":1000815,"_ver":1},{"_value":1000818,"_ver":1}]}' });
+            } else if (apiUrl === '/book-operate/share_3') {
+                res.status(200).json({ userId: 'test_user_id', parameter: '{"document":[{"_value":1001010,"_ver":1}],"event":[{"_value":1000811,"_ver":1}],"thing":[{"_value":1000814,"_ver":1},{"_value":1000815,"_ver":1}]}' });
+            } else if (apiUrl === '/book-operate/share_4') {
+                res.status(200).json({ userId: 'test_user_id', parameter: '{"document":[{"_value":1001010,"_ver":1}],"event":[{"_value":1000811,"_ver":1}],"thing":[{"_value":1000814,"_ver":1},{"_value":1000818,"_ver":1}]}' });
+            } else {
+                res.status(200).json({ userId: 'test_user_id', parameter: null });
+            }
         });
         this.server = this.app.listen(3015);
     }

--- a/src/tests/mocks.port.json
+++ b/src/tests/mocks.port.json
@@ -3,5 +3,6 @@
     "service-B": 4444,
     "service-C": 5555,
     "service-D": 6666,
-    "binary-manage": 3018
+    "binary-manage": 3018,
+    "book-operate": 3006
 }


### PR DESCRIPTION
## 修正内容

### プロキシサービス.プロキシAPI
- POST pxr-block-proxy/
- PUT pxr-block-proxy/
- DELETE pxr-block-proxy/

- 利用ケース
    -ブロック間通信、外部通信でAPIを呼び出す際、必ずこのAPIを経由する。
- 修正内容
    - アクセス制御サービスのAPIトークン取得からエラーレスポンスが返却された際、それが蓄積・共有不可判定によるエラーの場合は専用のエラーメッセージを送出するよう修正
    - GET メソッドは蓄積/共有可否判定に関係しないため修正対象外

### プロキシサービス.リバースプロキシAPI
- POST pxr-block-proxy/reverse

- 利用ケース
    - リクエスト元ブロックのプロキシから呼び出され、リクエスト先のPOSTメソッドのAPIを呼び出す。
    - プロキシ経由（ブロック間通信、外部通信）でAPIを呼び出す際、必ずこのAPIを経由する。

- 修正内容
    - APIトークン認証依頼（POST /access-control/collate）の返却値を受け取る変数の追加
        - access-control 側は、既存処理でAPIトークンに紐づけられたデータ種情報を返却するようになっているため修正不要
    - プロキシーログをDBに登録後、レスポンス生成処理前に以下処理を追加
        - dto.toPath が 「/book-operate/share/search」の場合のみ、レスポンスのモノとAPIトークン認証依頼レスポンスのデータ種を照合する
            - APIトークン認証依頼レスポンスのデータ種に含まれないモノをレスポンスから除外する
   - GET, PUT, DELETE メソッドは、パスが「/book-operate/share/search」のAPIが存在しないため修正対象外

- 修正目的・経緯
    - 既存処理ではbook-operate/shareで行っていたレスポンスのモノのフィルタ処理の移行
        - 共有可能イベント配下のモノについて、共有が許可されているもののみにフィルタする目的の処理
        - 移行先として共有元book-operate と reverseProxy の選択肢があったが、APIトークンから共有可データ種を取得するにあたってI/F変更や、追加のAPI呼出が不要な点からreverseProxy側で行う方針にした
    - 蓄積のケースもAPIトークン認証依頼のレスポンスにデータ種情報が含まれるが、蓄積レスポンスを変更する必要はないため対応不要
 
fixes #15

## UnitTest

### UT環境
```
$ node --version
v18.16.1
```
```
$ psql -V
psql (PostgreSQL) 15.6
```

### UT実行結果
```
$ npm run test:unit

> pxr-block-proxy-service@1.0.0 test:unit
> jest --coverage --forceExit --detectOpenHandles --runInBand --config=jest.unit.config.js

PASS src/tests/ReverseProxy.spec.ts (26.689 s)
PASS src/tests/Proxy.spec.ts (7.255 s)
PASS src/tests/UsingMultipleApiKeysOnceRequest.spec.ts (8.195 s)
PASS src/tests/UsingMultipleApiKeysOnceRequest.ind.spec.ts (6.072 s)
PASS src/tests/AbnormalProxy.catalog.spec.ts
PASS src/tests/AbnormalProxy.token.spec.ts
PASS src/tests/AbnormalProxy.auth.spec.ts
PASS src/tests/Proxy.auth.spec.ts
PASS src/tests/AbnormalProxy.reverse.spec.ts
PASS src/tests/AbnormalReverseProxy.token.spec.ts
(node:10872) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 message listeners added to [EventEmitter]. Use emitter.setMaxListeners() to increase limit
(Use `node --trace-warnings ...` to show where the warning was created)
PASS src/tests/BufferRequest.spec.ts
----------------------------|---------|----------|---------|---------|-------------------
File                        | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
----------------------------|---------|----------|---------|---------|-------------------
All files                   |   99.66 |    98.65 |     100 |   99.65 |
 src                        |     100 |      100 |     100 |     100 |
  index.ts                  |     100 |      100 |     100 |     100 |
 src/domains                |     100 |      100 |     100 |     100 |
  CatalogDomain.ts          |     100 |      100 |     100 |     100 |
  ProxyRequestDomain.ts     |     100 |      100 |     100 |     100 |
 src/repositories           |     100 |      100 |     100 |     100 |
  EntityOperation.ts        |     100 |      100 |     100 |     100 |
 src/repositories/postgres  |     100 |      100 |     100 |     100 |
  ProxyLog.ts               |     100 |      100 |     100 |     100 |
 src/resources              |     100 |      100 |     100 |     100 |
  IndProxyController.ts     |     100 |      100 |     100 |     100 |
  ProxyController.ts        |     100 |      100 |     100 |     100 |
  ReverseProxyController.ts |     100 |      100 |     100 |     100 |
 src/resources/dto          |     100 |      100 |     100 |     100 |
  ProxyReqDto.ts            |     100 |      100 |     100 |     100 |
 src/resources/validator    |     100 |      100 |     100 |     100 |
  ProxyValidator.ts         |     100 |      100 |     100 |     100 |
 src/services               |   99.24 |    98.34 |     100 |   99.23 |
  AccessControlService.ts   |     100 |      100 |     100 |     100 |
  CatalogService.ts         |     100 |      100 |     100 |     100 |
  ProxyService.ts           |     100 |      100 |     100 |     100 |
  ReverseProxyService.ts    |   97.97 |    96.72 |     100 |   97.89 | 141,193
 src/services/dto           |     100 |      100 |     100 |     100 |
  ProxyServiceDTO.ts        |     100 |      100 |     100 |     100 |
----------------------------|---------|----------|---------|---------|-------------------

Test Suites: 11 passed, 11 total
Tests:       171 passed, 171 total
Snapshots:   0 total
Time:        73.88 s
Ran all test suites.
```