### PR TITLE
継続的共有／一時的共有のレスポンスが配列にならない場合がある問題の修正 issue/#19

### DIFF
--- a/src/resources/ProxyController.ts
+++ b/src/resources/ProxyController.ts
@@ -154,7 +154,7 @@ export default class ProxyController {
             res
                 .status(result.response.statusCode)
                 .header(result.response.headers)
-                .send(result.body);
+                .send(dto.toPath === '/book-operate/share/search' ? [result.body] : result.body);
         } else {
             const results: {
                 response: request.Response;

--- a/src/tests/Proxy.spec.ts
+++ b/src/tests/Proxy.spec.ts
@@ -19,7 +19,8 @@ import {
     StubAccessControlService,
     StubOperatorService,
     StubCatalogService,
-    StubReverseProxyAPI
+    StubReverseProxyAPI,
+    BookOperateResponseService
 } from './StubServer';
 /* eslint-enable */
 
@@ -38,6 +39,7 @@ let _mockOperatorService: StubOperatorService;
 let _mockCatalogService: StubCatalogService;
 let _mockReverseProxyAPI: StubReverseProxyAPI;
 let _fromServerBinary: BinaryResponseService;
+let _mockBookOperateService: BookOperateResponseService;
 
 // PXR-Block-Proxy Service APIのユニットテスト
 describe('PXR-Block-Proxy Service API', () => {
@@ -55,6 +57,7 @@ describe('PXR-Block-Proxy Service API', () => {
         _mockCatalogService = new StubCatalogService();
         _mockReverseProxyAPI = new StubReverseProxyAPI();
         _fromServerBinary = new BinaryResponseService(3018, '/binary-manage/download/:id/:chunkNo');
+        _mockBookOperateService = new BookOperateResponseService(3006, 0);
     });
     // テストがすべて終了したら実行する事後処理
     afterAll(async () => {
@@ -70,6 +73,7 @@ describe('PXR-Block-Proxy Service API', () => {
         _mockCatalogService.server.close();
         _mockReverseProxyAPI.server.close();
         _fromServerBinary.server.close();
+        _mockBookOperateService.server.close();
 
         // 元のファイル状態に変更する
         fs.writeFileSync('./config/port.json', beforeFileLines);
@@ -498,6 +502,308 @@ describe('PXR-Block-Proxy Service API', () => {
 
             // Expect status Success code.
             expect(JSON.stringify(response.body)).toBe(JSON.stringify({}));
+            expect(response.status).toBe(200);
+        });
+
+        // 正常系のPOSTプロキシー(toPathが/book-operate/share/searchの場合)
+        test('正常系: POST', async () => {
+            const response = await supertest(expressApp)
+                .post(baseURI)
+                .query({
+                    block: 5555555,
+                    from_block: 3333333,
+                    path: encodeURIComponent('/book-operate/share/search'),
+                    from_path: encodeURIComponent('/book-operate/share')
+                })
+                .set({
+                    'Content-Type': 'application/json',
+                    accept: 'application/json'
+                })
+                .set('Cookie', ['operator_type3_session=8947a6a73a6c8f952fe73678d84c2684892921bbdbd3a10fe910a7a8d3bb5aa6'])
+                .send(JSON.stringify(
+                    {
+                        userId: 'test_user1',
+                        identifier: [],
+                        logIdentifier: '1',
+                        app: {
+                            _value: 1000481
+                        },
+                        wf: null,
+                        document: [
+                            {
+                                _value: 1001010,
+                                _ver: 1
+                            }
+                        ],
+                        event: [
+                            {
+                                _value: 1000811,
+                                _ver: 1
+                            }
+                        ],
+                        thing: [
+                            {
+                                _value: 1000814,
+                                _ver: 1
+                            },
+                            {
+                                _value: 1000815,
+                                _ver: 1
+                            },
+                            {
+                                _value: 1000818,
+                                _ver: 1
+                            }
+                        ]
+                    }));
+
+            // Expect status Success code.
+            expect(JSON.stringify(response.body)).toBe(JSON.stringify([{
+                document: [
+                    {
+                        id: {
+                            index: '2_1_1',
+                            value: 'doc01-89bb-f8f2-74a0-dc517da60653'
+                        },
+                        code: {
+                            index: '2_1_2',
+                            value: {
+                                _value: 1001010,
+                                _ver: 1
+                            }
+                        },
+                        createdAt: {
+                            index: '2_2_1',
+                            value: '2020-02-20 00:00:00'
+                        },
+                        sourceId: '20200221-1',
+                        wf: null,
+                        app: {
+                            code: {
+                                index: '2_3_1',
+                                value: {
+                                    _value: 1000438,
+                                    _ver: 1
+                                }
+                            },
+                            app: {
+                                index: '2_3_5',
+                                value: {
+                                    _value: 1000481,
+                                    _ver: 1
+                                }
+                            },
+                            staffId: {
+                                index: '2_3_4',
+                                value: 'staffId'
+                            }
+                        },
+                        chapter: [
+                            {
+                                title: 'タイトル１',
+                                event: [
+                                    'doc01-eve01-8eb5-9b57-ac1980208f21',
+                                    'doc01-eve02-e230-930c-c43d5050b9d3'
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                event: [
+                    {
+                        id: {
+                            index: '3_1_1',
+                            value: 'doc01-eve01-8eb5-9b57-ac1980208f21'
+                        },
+                        code: {
+                            index: '3_1_2',
+                            value: {
+                                _value: 1000811,
+                                _ver: 1
+                            }
+                        },
+                        start: {
+                            index: '3_2_1',
+                            value: '2020-02-20 00:00:00'
+                        },
+                        end: {
+                            index: '3_2_2',
+                            value: '2020-02-21 00:00:00'
+                        },
+                        location: {
+                            index: '3_3_1',
+                            value: 'location'
+                        },
+                        sourceId: '20200221-1',
+                        env: null,
+                        wf: null,
+                        app: {
+                            code: {
+                                index: '3_5_1',
+                                value: {
+                                    _value: 1000438,
+                                    _ver: 1
+                                }
+                            },
+                            app: {
+                                index: '3_5_5',
+                                value: {
+                                    _value: 1000481,
+                                    _ver: 1
+                                }
+                            }
+                        },
+                        thing: [
+                            {
+                                acquired_time: {
+                                    index: '4_2_2_4',
+                                    value: null
+                                },
+                                code: {
+                                    index: '4_1_2',
+                                    value: {
+                                        _value: 1000814,
+                                        _ver: 1
+                                    }
+                                },
+                                env: null,
+                                sourceId: '20200221-1',
+                                id: {
+                                    index: '4_1_1',
+                                    value: 'doc01-eve01-thi01-c4e0-130b2788dcf4'
+                                },
+                                wf: null,
+                                app: {
+                                    code: {
+                                        index: '3_5_1',
+                                        value: {
+                                            _value: 1000438,
+                                            _ver: 1
+                                        }
+                                    },
+                                    app: {
+                                        index: '3_5_5',
+                                        value: {
+                                            _value: 1000481,
+                                            _ver: 1
+                                        }
+                                    }
+                                },
+                                'x-axis': {
+                                    index: '4_2_2_1',
+                                    value: null
+                                },
+                                'y-axis': {
+                                    index: '4_2_2_2',
+                                    value: null
+                                },
+                                'z-axis': {
+                                    index: '4_2_2_3',
+                                    value: null
+                                }
+                            },
+                            {
+                                acquired_time: {
+                                    index: '4_2_2_4',
+                                    value: null
+                                },
+                                code: {
+                                    index: '4_1_2',
+                                    value: {
+                                        _value: 1000815,
+                                        _ver: 1
+                                    }
+                                },
+                                env: null,
+                                sourceId: '20200221-1',
+                                id: {
+                                    index: '4_1_1',
+                                    value: 'doc01-eve01-thi01-1171a3b52499'
+                                },
+                                wf: null,
+                                app: {
+                                    code: {
+                                        index: '3_5_1',
+                                        value: {
+                                            _value: 1000438,
+                                            _ver: 1
+                                        }
+                                    },
+                                    app: {
+                                        index: '3_5_5',
+                                        value: {
+                                            _value: 1000481,
+                                            _ver: 1
+                                        }
+                                    }
+                                },
+                                'x-axis': {
+                                    index: '4_2_2_1',
+                                    value: null
+                                },
+                                'y-axis': {
+                                    index: '4_2_2_2',
+                                    value: null
+                                },
+                                'z-axis': {
+                                    index: '4_2_2_3',
+                                    value: null
+                                }
+                            }
+                        ]
+                    }
+                ],
+                thing: [
+                    {
+                        acquired_time: {
+                            index: '4_2_2_4',
+                            value: null
+                        },
+                        code: {
+                            index: '4_1_2',
+                            value: {
+                                _value: 1000818,
+                                _ver: 1
+                            }
+                        },
+                        env: null,
+                        sourceId: '20200221-1',
+                        id: {
+                            index: '4_1_1',
+                            value: 'doc01-eve01-thi01-c4e0-130b2788dcf4'
+                        },
+                        wf: null,
+                        app: {
+                            code: {
+                                index: '3_5_1',
+                                value: {
+                                    _value: 1000438,
+                                    _ver: 1
+                                }
+                            },
+                            app: {
+                                index: '3_5_5',
+                                value: {
+                                    _value: 1000481,
+                                    _ver: 1
+                                }
+                            }
+                        },
+                        'x-axis': {
+                            index: '4_2_2_1',
+                            value: null
+                        },
+                        'y-axis': {
+                            index: '4_2_2_2',
+                            value: null
+                        },
+                        'z-axis': {
+                            index: '4_2_2_3',
+                            value: null
+                        }
+                    }
+                ]
+            }]));
             expect(response.status).toBe(200);
         });
 


### PR DESCRIPTION
## 修正内容
* 共有レスポンスが必ず配列になるように修正

fixes #19

## UT環境
~~~
node --version
v18.12.0

psql -U postgres -h localhost -p 5432 -c "SELECT version();"
ユーザー postgres のパスワード:

                          version
------------------------------------------------------------
 PostgreSQL 15.7, compiled by Visual C++ build 1939, 64-bit
(1 行)
~~~

## UT実行結果
~~~
> npm run test:unit

> pxr-block-proxy-service@1.0.0 test:unit
> jest --coverage --forceExit --detectOpenHandles --runInBand --config=jest.unit.config.js

 PASS  src/tests/Proxy.auth.spec.ts (8.32 s)
 PASS  src/tests/ReverseProxy.spec.ts
 PASS  src/tests/Proxy.spec.ts
 PASS  src/tests/UsingMultipleApiKeysOnceRequest.spec.ts (5.064 s)
 PASS  src/tests/UsingMultipleApiKeysOnceRequest.ind.spec.ts
 PASS  src/tests/AbnormalProxy.catalog.spec.ts
 PASS  src/tests/AbnormalProxy.token.spec.ts (5.901 s)
 PASS  src/tests/AbnormalProxy.reverse.spec.ts
 PASS  src/tests/AbnormalReverseProxy.token.spec.ts
 PASS  src/tests/AbnormalProxy.auth.spec.ts
(node:10312) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 message listeners added to [EventEmitter]. Use emitter.setMaxListeners() to increase limit
(Use `node --trace-warnings ...` to show where the warning was created)
 PASS  src/tests/BufferRequest.spec.ts
----------------------------|---------|----------|---------|---------|-------------------
File                        | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
----------------------------|---------|----------|---------|---------|-------------------
All files                   |   99.66 |    98.67 |     100 |   99.65 |
 src                        |     100 |      100 |     100 |     100 |
  index.ts                  |     100 |      100 |     100 |     100 |
 src/domains                |     100 |      100 |     100 |     100 |
  CatalogDomain.ts          |     100 |      100 |     100 |     100 |
  ProxyRequestDomain.ts     |     100 |      100 |     100 |     100 |
 src/repositories           |     100 |      100 |     100 |     100 |
  EntityOperation.ts        |     100 |      100 |     100 |     100 |
 src/repositories/postgres  |     100 |      100 |     100 |     100 |
  ProxyLog.ts               |     100 |      100 |     100 |     100 |
 src/resources              |     100 |      100 |     100 |     100 |
  IndProxyController.ts     |     100 |      100 |     100 |     100 |
  ProxyController.ts        |     100 |      100 |     100 |     100 |
  ReverseProxyController.ts |     100 |      100 |     100 |     100 |
 src/resources/dto          |     100 |      100 |     100 |     100 |
  ProxyReqDto.ts            |     100 |      100 |     100 |     100 |
 src/resources/validator    |     100 |      100 |     100 |     100 |
  ProxyValidator.ts         |     100 |      100 |     100 |     100 |
 src/services               |   99.24 |    98.34 |     100 |   99.23 |
  AccessControlService.ts   |     100 |      100 |     100 |     100 |
  CatalogService.ts         |     100 |      100 |     100 |     100 |
  ProxyService.ts           |     100 |      100 |     100 |     100 |
  ReverseProxyService.ts    |   97.97 |    96.72 |     100 |   97.89 | 141,193
 src/services/dto           |     100 |      100 |     100 |     100 |
  ProxyServiceDTO.ts        |     100 |      100 |     100 |     100 |
----------------------------|---------|----------|---------|---------|-------------------

Test Suites: 11 passed, 11 total
Tests:       172 passed, 172 total
Snapshots:   0 total
Time:        45.259 s
Ran all test suites.
~~~