### PR TITLE
bugfix/#21GracefulShutdown組み込み対応

### DIFF
--- a/src/resources/config/Application.ts
+++ b/src/resources/config/Application.ts
@@ -44,6 +44,13 @@ export class Application {
             this.server.keepAliveTimeout = 0;
             this.server.headersTimeout = 0;
         }
+
+        process.on('SIGTERM', () => {
+            // サーバをシャットダウンする
+            this.server.close(() => {
+                systemLogger.info('SIGTERM signal received.');
+            });
+        });
     }
 
     async start () {


### PR DESCRIPTION
# bugfix/#21GracefulShutdown組み込み対応

## 修正内容

- GracefulShutdown組み込み対応

Fixes #21

## UT環境

```bash
$ node -v
v18.20.5

$ psql -U postgres -h localhost -p 5432 -c "SELECT version();"

                                                        version
-----------------------------------------------------------------------------------------------------------------------
 PostgreSQL 15.10 (Debian 15.10-1.pgdg120+1) on x86_64-pc-linux-gnu, compiled by gcc (Debian 12.2.0-14) 12.2.0, 64-bit
(1 行)
```

### UT実行結果

```bash
$ npm run test:unit

> pxr-block-proxy-service@1.0.0 test:unit
> jest --coverage --forceExit --detectOpenHandles --runInBand --config=jest.unit.config.js

 PASS  src/tests/ReverseProxy.spec.ts (231.791 s)
 PASS  src/tests/Proxy.spec.ts (40.627 s)
 PASS  src/tests/UsingMultipleApiKeysOnceRequest.spec.ts (40.057 s)
 PASS  src/tests/UsingMultipleApiKeysOnceRequest.ind.spec.ts (35.472 s)
 PASS  src/tests/AbnormalProxy.catalog.spec.ts (28.995 s)
 PASS  src/tests/AbnormalProxy.token.spec.ts (29.353 s)
 PASS  src/tests/AbnormalProxy.auth.spec.ts (27.749 s)
 PASS  src/tests/Proxy.auth.spec.ts (38.601 s)
 PASS  src/tests/AbnormalProxy.reverse.spec.ts (31.294 s)
 PASS  src/tests/AbnormalReverseProxy.token.spec.ts (29.015 s)
(node:7914) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 message listeners added to [EventEmitter]. Use emitter.setMaxListeners() to increase limit
(Use `node --trace-warnings ...` to show where the warning was created)
 PASS  src/tests/BufferRequest.spec.ts (29.536 s)
----------------------------|---------|----------|---------|---------|-------------------
File                        | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
----------------------------|---------|----------|---------|---------|-------------------
All files                   |   99.66 |    98.67 |     100 |   99.65 |                   
 src                        |     100 |      100 |     100 |     100 |                   
  index.ts                  |     100 |      100 |     100 |     100 |                   
 src/domains                |     100 |      100 |     100 |     100 |                   
  CatalogDomain.ts          |     100 |      100 |     100 |     100 |                   
  ProxyRequestDomain.ts     |     100 |      100 |     100 |     100 |                   
 src/repositories           |     100 |      100 |     100 |     100 |                   
  EntityOperation.ts        |     100 |      100 |     100 |     100 |                   
 src/repositories/postgres  |     100 |      100 |     100 |     100 |                   
  ProxyLog.ts               |     100 |      100 |     100 |     100 |                   
 src/resources              |     100 |      100 |     100 |     100 |                   
  IndProxyController.ts     |     100 |      100 |     100 |     100 |                   
  ProxyController.ts        |     100 |      100 |     100 |     100 |                   
  ReverseProxyController.ts |     100 |      100 |     100 |     100 |                   
 src/resources/dto          |     100 |      100 |     100 |     100 |                   
  ProxyReqDto.ts            |     100 |      100 |     100 |     100 |                   
 src/resources/validator    |     100 |      100 |     100 |     100 |                   
  ProxyValidator.ts         |     100 |      100 |     100 |     100 |                   
 src/services               |   99.24 |    98.34 |     100 |   99.23 |                   
  AccessControlService.ts   |     100 |      100 |     100 |     100 |                   
  CatalogService.ts         |     100 |      100 |     100 |     100 |                   
  ProxyService.ts           |     100 |      100 |     100 |     100 |                   
  ReverseProxyService.ts    |   97.97 |    96.72 |     100 |   97.89 | 141,193           
 src/services/dto           |     100 |      100 |     100 |     100 |                   
  ProxyServiceDTO.ts        |     100 |      100 |     100 |     100 |                   
----------------------------|---------|----------|---------|---------|-------------------

Test Suites: 11 passed, 11 total
Tests:       172 passed, 172 total
Snapshots:   0 total
Time:        572.189 s
Ran all test suites.
```
